### PR TITLE
Update zh_CN.json

### DIFF
--- a/Locales/scripts/zh_CN.json
+++ b/Locales/scripts/zh_CN.json
@@ -56,7 +56,7 @@
             "render_success": "[pdf_renderer] 渲染成功",
             "rendering": "[pdf_renderer] 正在渲染：{file}",
             "rendering_img": "[pdf_renderer] 正在渲染图片：{img}"
-        },
+        }
     },
     "PDFMerger": {
         "debug": {


### PR DESCRIPTION
Remove extra commas in the configuration file to fix the following error when start up.
```
(.venv) louise@novo:~/GOT-OCR-2-GUI$ python GUI.py
正在加载 / Loading...
Traceback (most recent call last):
  File "/home/ylin/GOT-OCR-2-GUI/GUI.py", line 5, in <module>
    import scripts.Renderer as Renderer
  File "/home/ylin/GOT-OCR-2-GUI/scripts/__init__.py", line 67, in <module>
    local = json.load(file)
            ^^^^^^^^^^^^^^^
  File "/home/ylin/miniconda3/lib/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/home/ylin/miniconda3/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ylin/miniconda3/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ylin/miniconda3/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 60 column 5 (char 2707)
```